### PR TITLE
Fixed issue #20 and losing is way more complete :rice_ball

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -96,7 +96,7 @@ class Board < Observable
   end
 
   def show_bombs
-    @matrix.each_with_index do |row|
+    @matrix.each do |row|
       row.each do |cell|
         cell.discovered = true if cell.type == CellType::MINE
       end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -85,4 +85,17 @@ class Board < Observable
     end
     printable_board
   end
+
+  def show_bombs
+    @matrix.each_with_index do |row, index|
+      row.each do |cell|
+        cell.discovered = true if cell.type == CellType::MINE
+      end
+    end
+  end
+
+  def explode_bomb(y_coordinate, x_coordinate)
+    cell = @matrix[y_coordinate][x_coordinate]
+    cell.type = CellType::EXPLODED
+  end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -96,7 +96,7 @@ class Board < Observable
   end
 
   def show_bombs
-    @matrix.each_with_index do |row, index|
+    @matrix.each_with_index do |row|
       row.each do |cell|
         cell.discovered = true if cell.type == CellType::MINE
       end

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -63,7 +63,7 @@ class Cell
   end
 
   def show_discovered
-    return @type if empty || @type == CellType::MINE
+    return @type if empty || @type == CellType::MINE || @type == CellType::EXPLODED
 
     @adjacent_mines
   end

--- a/lib/constants/cell_type.rb
+++ b/lib/constants/cell_type.rb
@@ -5,4 +5,5 @@ module CellType
   SAFE = '  '
   MINE = '💣'
   FLAGGED = '🚩'
+  EXPLODED = '💥'
 end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -78,11 +78,16 @@ class Game
       valid = @board.flag_cell(x_coordinate.to_i, y_coordinate.to_i)
     end
     say("❗ Cannot #{choice} a #{valid} cell ❗") if %w[discovered flagged].include?(valid)
-    lose if valid == 'explosion'
+    lose(y_coordinate.to_i, x_coordinate.to_i) if valid == 'explosion'
   end
 
-  def lose
+  def lose(y_coordinate, x_coordinate)
     say('💥 You stepped on a MINE 💥')
+    @board.explode_bomb(y_coordinate, x_coordinate)
+    @board.show_bombs
+    @board.print
+    puts 'You lost :('
+    @playing = false
   end
 
   def win_check


### PR DESCRIPTION
## What?
Fixed issue #20. When you lose the game actually ends now. It also shows you where all the other mines are, and where the mine you exploded is.

## Why?
If it was not for this you would be able to play until you win even if you had stepped on a mine.

## Tests?
Manually tested stepping on a mine.

## Screenshots
![image](https://user-images.githubusercontent.com/32397663/135661578-75554b43-ebf2-4d79-8e69-ad7df8d09cd3.png)

## Anything else?
In the screenshot it just so happened that the first place I chose was a mine, that is why all the other cells are hidden, but in any other case the console will still show everything that has been discovered.
The game also finishes when you lose, so you have to run the application again to play again.
